### PR TITLE
STYLE: Upgrade python syntax to 3.6 and newer

### DIFF
--- a/AnglePlanes/AnglePlanes.py
+++ b/AnglePlanes/AnglePlanes.py
@@ -270,7 +270,7 @@ class AnglePlanesWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def onChangeMiddlePointFiducialNode(self):
         key = self.selectPlaneForMidPoint.currentText
-        if key is "":
+        if key == "":
             return
         plane = self.planeControlsDictionary[key]
         fidList = plane.fidlist
@@ -857,7 +857,7 @@ class AnglePlanesLogic(ScriptedLoadableModuleLogic):
     def isUnderTransform(self, markups):
         if markups.GetParentTransformNode():
             messageBox = ctk.ctkMessageBox()
-            messageBox.setWindowTitle(" /!\ WARNING /!\ ")
+            messageBox.setWindowTitle(r" /!\ WARNING /!\ ")
             messageBox.setIcon(messageBox.Warning)
             messageBox.setText("Your Markup Fiducial Node is currently modified by a transform,"
                                "if you choose to continue the program will apply the transform"
@@ -880,7 +880,7 @@ class AnglePlanesLogic(ScriptedLoadableModuleLogic):
 
     def connectedModelChangement(self):
         messageBox = ctk.ctkMessageBox()
-        messageBox.setWindowTitle(" /!\ WARNING /!\ ")
+        messageBox.setWindowTitle(r" /!\ WARNING /!\ ")
         messageBox.setIcon(messageBox.Warning)
         messageBox.setText("The Markup Fiducial Node selected is curently projected on an"
                            "other model, if you chose to continue the fiducials will be  "
@@ -1592,7 +1592,7 @@ class AnglePlanesLogic(ScriptedLoadableModuleLogic):
 
     def warningMessage(self, message):
         messageBox = ctk.ctkMessageBox()
-        messageBox.setWindowTitle(" /!\ WARNING /!\ ")
+        messageBox.setWindowTitle(r" /!\ WARNING /!\ ")
         messageBox.setIcon(messageBox.Warning)
         messageBox.setText(message)
         messageBox.setStandardButtons(messageBox.Ok)
@@ -1635,10 +1635,10 @@ class AnglePlanesTest(ScriptedLoadableModuleTest):
             filePath = slicer.app.temporaryPath + '/' + name
             print(filePath)
             if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
-                logging.info('Requesting download %s from %s...\n' % (name, url))
+                logging.info(f'Requesting download {name} from {url}...\n')
                 urllib.request.urlretrieve(url, filePath)
             if loader:
-                logging.info('Loading %s...' % (name,))
+                logging.info(f'Loading {name}...')
                 loader(filePath)
 
         layoutManager = slicer.app.layoutManager()


### PR DESCRIPTION
Some syntax upgrading is necessary for AnglePlanes-Extension as I noticed in https://slicer.cdash.org/viewBuildError.php?buildid=2581381 that there were syntax warnings. These warnings are present because Slicer recently upgrade from Python 3.6.7 to Python 3.9.10 in https://github.com/Slicer/Slicer/commit/34e48e8aef5dad19ec8a955d6f48a1940846e3f3.

The syntax warning in question started as of Python 3.8.
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

> The compiler now produces a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in [bpo-34850](https://bugs.python.org/issue34850).)

This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. The script listed below was run for Python 3.6+ syntax with changes committed, followed by Python 3.7+, then Python 3.8+ and finally Python 3.9+.  There were no changes made when specifying Python 3.7+, 3.8+ or 3.9+ which is why there are no commits for those iterations.

## Using pyupgrade

- Install: `PythonSlicer -m pip install pyupgrade`
- Running:
  - On 1 file: `PythonSlicer -m pyupgrade --py36-plus MyPythonFile.py`
  - On multiple files: Here is my pyupgrade-script.py written to automate running pyupgrade across all python files in the Slicer repo. It was run by `PythonSlicer pyupgrade-script.py`.
```python
# pyupgrade-script.py
import os
import subprocess

search_directory = "C:/Users/JamesButler/Documents/GitHub/AnglePlanes-Extension"
for root, _, files in os.walk(search_directory):
    for file_item in files:
        file_path = os.path.join(root, file_item)
        if os.path.isfile(file_path) and file_path.endswith(".py"):
            subprocess.call(["PythonSlicer", "-m", "pyupgrade", "--py36-plus", file_path])
```